### PR TITLE
Center cards on screen

### DIFF
--- a/app/components/PostCard/look.js
+++ b/app/components/PostCard/look.js
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 export const Wrapper = styled.section`
   display: flex;
   width: 100%;
-  max-width: 600px;
   margin: 0.5rem 0;
   border: 1px solid rgb(204, 204, 204);
   border-radius: 0.25rem;

--- a/app/components/PostFactory/look.js
+++ b/app/components/PostFactory/look.js
@@ -2,8 +2,9 @@ import styled from 'styled-components';
 
 export const List = styled.ul`
   padding: 8rem 2rem 1rem;
-  margin: 0;
+  margin: 0 auto;
   list-style: none;
+  max-width: 900px;
 
   > li {
     list-style: none;
@@ -12,4 +13,5 @@ export const List = styled.ul`
 
 export const Feedback = styled.p`
   padding: 10rem 2rem;
+  text-align: center;
 `;

--- a/app/containers/HomePage/look.js
+++ b/app/containers/HomePage/look.js
@@ -3,10 +3,12 @@ import styled from 'styled-components';
 export const FilterSection = styled.section`
   display: flex;
   align-items: center;
+  justify-content: center;
 `;
 
 export const Heading = styled.h1`
   margin: 0 0 1rem;
+  text-align: center;
 `;
 
 export const NavigationBar = styled.nav`


### PR DESCRIPTION
This PR aligns post cards to the center of the screen in order to make a better use of the available space. 

The original idea was to have an iframe like on the right half of the screen to load the links from the posts that the user would click, but it didn't work fine as most of the links were from reddit and they didn't allow content to be shown in an iframe. I'll get back to the idea in a later point with more time. For now, aligning the posts to the center seemed to work fine.

![image](https://user-images.githubusercontent.com/10034981/51096081-d9ee7380-17a0-11e9-85e7-d64c7fab78ff.png)

![image](https://user-images.githubusercontent.com/10034981/51096097-099d7b80-17a1-11e9-9d88-e4485f76a219.png)

